### PR TITLE
Fix disparity smoothness missing y gradient

### DIFF
--- a/monodepth_model.py
+++ b/monodepth_model.py
@@ -352,8 +352,8 @@ class MonodepthModel(object):
             self.image_loss = tf.add_n(self.image_loss_left + self.image_loss_right)
 
             # DISPARITY SMOOTHNESS
-            self.disp_left_loss  = [tf.reduce_mean(tf.abs(self.disp_left_smoothness[i]))  / 2 ** i for i in range(4)]
-            self.disp_right_loss = [tf.reduce_mean(tf.abs(self.disp_right_smoothness[i])) / 2 ** i for i in range(4)]
+            self.disp_left_loss  = [tf.reduce_mean(tf.abs(self.disp_left_smoothness[i]))  / 2 ** i for i in range(4 * 2)]
+            self.disp_right_loss = [tf.reduce_mean(tf.abs(self.disp_right_smoothness[i])) / 2 ** i for i in range(4 * 2)]
             self.disp_gradient_loss = tf.add_n(self.disp_left_loss + self.disp_right_loss)
 
             # LR CONSISTENCY


### PR DESCRIPTION
In `get_disparity_smoothness`:
 https://github.com/mrharicot/monodepth/blob/5bc4bb1eaf6f6c78ec3bcda37af4eeea9fc4f0c6/monodepth_model.py#L121)

the two lists for the `x` and `y` direction are concatenated while the loss in your paper suggests to use elementwise addition. To fix this you could either pad the gradients on the right side and bottom by `1` or simply iterate over the 8 instead of 4 elements of the gradients list. Else you disregard the y gradients as the first 4 entries are only the x gradients. 